### PR TITLE
Fix experience timeline dates

### DIFF
--- a/assets/js/experience.js
+++ b/assets/js/experience.js
@@ -8,14 +8,14 @@ const exp = [
     title: "AI Engineer D2.1 (Mid Level)",
     cardImage: "assets/images/experience-page/logo-indra-soci-institucional-png.webp",
     place: "Indra",
-    time: "(Aug 2024 – Present)",
+    time: "(2025 – Present)",
     desp: "<li>Implementation of Artificial Intelligence models (ML and LLMs).</li><li>Design of infrastructure and architecture for AI solution deployment.</li><li>Active involvement in system vision and technical decision-making.</li><li>Focus on ML-Ops and LLM-Ops for project robustness and scalability.</li><li>Work on critical systems and Edge Computing.</li>",
   },
   {
     title: "Research Engineer, BI-ML/Ops, Data Engineer",
     cardImage: "assets/images/experience-page/imdeanetworks.png",
     place: "IMDEA Networks Institute",
-    time: "(Aug 2023 – Present)",
+    time: "(Aug 2023 – 2025)",
     desp: "<li>Conducted data analysis on large-scale redundant databases to identify inefficiencies and optimize query responses.</li> <li>Developed proof-of-concept LLM-based solutions to improve information retrieval for business questions.</li> <li>Designed workflows for process automation and business intelligence reporting, improving decision-making efficiency.</li> <li>Integrated and optimized APIs for internal AI applications, facilitating data-driven insights across departments.</li> <li>Implementing and maintaining Kubernetes clusters for AI workloads, supporting scalable deployments.</li> <li>Developing and managing CI/CD pipelines for automating model training and deployment.</li> <li>Deploying and orchestrating workflows using Apache Airflow to streamline ML and data processing tasks.</li> <li>Utilizing MLflow as an interim solution for model tracking and deployment, planning migration to Kubeflow.</li>",
   },
   {

--- a/assets/js/experience_new.js
+++ b/assets/js/experience_new.js
@@ -8,7 +8,7 @@ const exp = [
     title: "Research Engineer, BI-ML/Ops, Data Engineer",
     cardImage: "assets/images/experience-page/imdea.png",
     place: "IMDEA Networks Institute",
-    time: "(Aug 2023 – Present)",
+    time: "(Aug 2023 – 2025)",
     desp: "<li>Conducted data analysis on large-scale redundant databases to identify inefficiencies and optimize query responses.</li> <li>Developed proof-of-concept LLM-based solutions to improve information retrieval for business questions.</li> <li>Designed workflows for process automation and business intelligence reporting, improving decision-making efficiency.</li> <li>Integrated and optimized APIs for internal AI applications, facilitating data-driven insights across departments.</li> <li>Implementing and maintaining Kubernetes clusters for AI workloads, supporting scalable deployments.</li> <li>Developing and managing CI/CD pipelines for automating model training and deployment.</li> <li>Deploying and orchestrating workflows using Apache Airflow to streamline ML and data processing tasks.</li> <li>Utilizing MLflow as an interim solution for model tracking and deployment, planning migration to Kubeflow.</li>",
   },
   {


### PR DESCRIPTION
## Summary
- update the Indra AI Engineer role to show a 2025 start date
- set the IMDEA Networks role to end in 2025 across the experience data files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9642925d483228764b0d24a97bff9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update displayed dates for Indra (2025–Present) and IMDEA (Aug 2023–2025) across experience data files.
> 
> - **Experience data updates**:
>   - `assets/js/experience.js`:
>     - Indra AI Engineer `time` → `(2025 – Present)`.
>     - IMDEA Networks `time` → `(Aug 2023 – 2025)`.
>   - `assets/js/experience_new.js`:
>     - IMDEA Networks `time` → `(Aug 2023 – 2025)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8946e5653fb21034791a517948230e592437006d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->